### PR TITLE
[Bug fix] ArithmeticException: / by zero

### DIFF
--- a/src/main/java/tonius/simplyjetpacks/item/jetpack/ItemArmoredJetpack.java
+++ b/src/main/java/tonius/simplyjetpacks/item/jetpack/ItemArmoredJetpack.java
@@ -26,8 +26,13 @@ public class ItemArmoredJetpack extends ItemJetpack {
 
     @Override
     public ArmorProperties getProperties(EntityLivingBase player, ItemStack armor, DamageSource source, double damage, int slot) {
-        int maxAbsorbed = this.getEnergyStored(armor) / this.energyPerDamage * 100;
-        return new ArmorProperties(0, this.armorAbsorption, maxAbsorbed);
+        if (this.energyPerDamage != 0) {
+            int maxAbsorbed = this.getEnergyStored(armor) / this.energyPerDamage * 100;
+            return new ArmorProperties(0, this.armorAbsorption, maxAbsorbed);
+        } else {
+            int maxAbsorbed = 12500000;
+            return new ArmorProperties(0, this.armorAbsorption, maxAbsorbed);
+        }
     }
 
     @Override


### PR DESCRIPTION
ArithmeticException: / by zero @ ItemArmoredJetpack.java:29 while using Creative Jetpack and taking damage.

This fixes the persistent crash after restart.

Note: I set the value on maxAbsorbed = 12500000 so we still get some protection from damage while using Creative Jetpack.
