### PR TITLE
Changed Default Energy Usage for Resonant Jetpack.

### DIFF
--- a/src/main/java/tonius/simplyjetpacks/config/SJConfig.java
+++ b/src/main/java/tonius/simplyjetpacks/config/SJConfig.java
@@ -101,7 +101,7 @@ public class SJConfig {
 
     // tuningResonant default
     public static final int resonantEnergyCapacity_default = 10000000;
-    public static final int resonantEnergyPerTick_default = 400;
+    public static final int resonantEnergyPerTick_default = 375;
     public static final double resonantSpeedVertical_default = 0.8D;
     public static final double resonantAccelVertical_default = 0.15D;
     public static final double resonantSpeedSideways_default = 0.19D;


### PR DESCRIPTION
Changed from 400 to 375 so that 375/1.5 is equal to 250. This fits better with the other tiers!
